### PR TITLE
fix messenger bot url

### DIFF
--- a/src/constants/config.constant.js
+++ b/src/constants/config.constant.js
@@ -3,4 +3,4 @@ if (tmpStr.charAt(tmpStr.length - 1) === '/') {
     tmpStr = tmpStr.slice(0, tmpStr.length - 1);
 }
 export const apiEndpoint = tmpStr;
-export const botMessengerUrl = process.env.REACT_APP_BOT_MESSENGER_URL || 'https://www.messenger.com/t/check.in.machine.test';
+export const botMessengerUrl = process.env.REACT_APP_BOT_MESSENGER_URL || 'https://m.me/check.in.machine.test';


### PR DESCRIPTION
要用 https://m.me/xxxxx 才會在瀏覽器上自動重導向到開啟 messenger 的頁面
env variable 已經改好